### PR TITLE
Update module for 2.18 provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This module deploys a VPC, Aviatrix transit gateways and firewall instances.
 ### Compatibility
 Module version | Terraform version | Controller version | Terraform provider version
 :--- | :--- | :--- | :---
+v3.0.1 | 0.13 | >=6.3 | >=0.2.18
 v3.0.0 | 0.13 | >=6.2 | >=0.2.17.2
 v2.0.2 | 0.12 | >=6.2 | >=0.2.17.1
 v2.0.1 | 0.12 | >=6.2 | >=0.2.17.1

--- a/output.tf
+++ b/output.tf
@@ -10,7 +10,7 @@ output "transit_gateway" {
 
 output "aviatrix_firenet" {
   description = "The Aviatrix firenet object with all of it's attributes"
-  value       = var.ha_gw ? aviatrix_firenet.firenet_ha[0] : aviatrix_firenet.firenet[0]
+  value       = aviatrix_firenet.firenet
 }
 
 output "aviatrix_firewall_instance" {

--- a/variables.tf
+++ b/variables.tf
@@ -91,9 +91,21 @@ variable "inspection_enabled" {
 }
 
 variable "egress_enabled" {
-  description = "Set to true to enable egress"
+  description = "Set to true to enable egress on FW instances"
   type        = bool
   default     = false
+}
+
+variable "enable_egress_transit_firenet" {
+  description = "Set to true to enable egress on transit gw"
+  type        = bool
+  default     = false
+}
+
+variable "local_as_number" {
+  description = "Changes the Aviatrix Transit Gateway ASN number before you setup Aviatrix Transit Gateway connection configurations."
+  type        = string
+  default     = ""
 }
 
 variable "insane_mode" {


### PR DESCRIPTION
Update the module for compatibility with 2.18 provider. 

local_as_number implemented to specify local BGP AS number when creating gateways.

Firewall instance associations reworked to use new resource in the 2.18 provider.