### PR TITLE
Expose keep alive via lan int param in avx_firenet

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ bgp_ecmp  | false | Enable Equal Cost Multi Path (ECMP) routing for the next h
 local_as_number | | Changes the Aviatrix Transit Gateway ASN number before you setup Aviatrix Transit Gateway connection configurations.
 enable_bgp_over_lan | false | Enable BGp over LAN. Creates eth4 for integration with SDWAN for example
 enable_egress_transit_firenet | false | Set to true to enable egress on transit gw
+keep_alive_via_lan_interface_enabled | false | Enable Keep Alive via Firewall LAN Interface
 
 ### Outputs
 This module will return the following objects:

--- a/main.tf
+++ b/main.tf
@@ -88,6 +88,7 @@ resource "aviatrix_firenet" "firenet" {
   vpc_id                               = aviatrix_vpc.default.vpc_id
   inspection_enabled                   = var.inspection_enabled
   egress_enabled                       = var.egress_enabled
+  keep_alive_via_lan_interface_enabled = var.keep_alive_via_lan_interface_enabled
   manage_firewall_instance_association = false
   depends_on                           = [aviatrix_firewall_instance_association.firenet_instance1, aviatrix_firewall_instance_association.firenet_instance2, aviatrix_firewall_instance_association.firenet_instance]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -102,6 +102,12 @@ variable "enable_egress_transit_firenet" {
   default     = false
 }
 
+variable "keep_alive_via_lan_interface_enabled" {
+  description = "Enable Keep Alive via Firewall LAN Interface"
+  type        = bool
+  default     = false
+}
+
 variable "local_as_number" {
   description = "Changes the Aviatrix Transit Gateway ASN number before you setup Aviatrix Transit Gateway connection configurations."
   type        = number


### PR DESCRIPTION
# What
Add keep_alive_via_lan_interface_enabled parameter to the module.

# Issue
https://github.com/terraform-aviatrix-modules/terraform-aviatrix-aws-transit-firenet/issues/25