### PR TITLE
V4.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ egress_static_cidrs | [] | List of egress static CIDRs. Egress is required to be
 firewall_image_id | | Custom Firewall image ID.
 learned_cidrs_approval_mode | | Learned cidrs approval mode. Defaults to Gateway. Valid values: gateway, connection
 
-
 ### Outputs
 This module will return the following objects:
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ tags | null | Map of tags to assign to the gateway.
 enable_multi_tier_transit |	false |	Switch to enable multi tier transit
 egress_static_cidrs | [] | List of egress static CIDRs. Egress is required to be enabled. Example: ["1.171.15.184/32", "1.171.15.185/32"].
 firewall_image_id | | Custom Firewall image ID.
+learned_cidrs_approval_mode | | Learned cidrs approval mode. Defaults to Gateway. Valid values: gateway, connection
+
 
 ### Outputs
 This module will return the following objects:

--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ resource "aviatrix_transit_gateway" "default" {
   ha_subnet                        = var.ha_gw ? local.ha_subnet : null
   enable_transit_firenet           = true
   ha_gw_size                       = var.ha_gw ? var.instance_size : null
-  connected_transit                = var.connected_transit
+  connected_transit                = var.enable_egress_transit_firenet ? false : var.connected_transit
   enable_hybrid_connection         = var.hybrid_connection
   bgp_manual_spoke_advertise_cidrs = var.bgp_manual_spoke_advertise_cidrs
   enable_learned_cidrs_approval    = var.learned_cidr_approval

--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,7 @@ resource "aviatrix_transit_gateway" "default" {
   tunnel_detection_time            = var.tunnel_detection_time
   tags                             = var.tags
   enable_multi_tier_transit        = var.enable_multi_tier_transit
+  learned_cidrs_approval_mode      = var.learned_cidrs_approval_mode
 }
 
 #Firewall instances

--- a/variables.tf
+++ b/variables.tf
@@ -264,6 +264,12 @@ variable "firewall_image_id" {
   default     = null
 }
 
+variable "learned_cidrs_approval_mode" {
+  description = "Learned cidrs approval mode. Defaults to Gateway. Valid values: gateway, connection"
+  type        = string
+  default     = null
+}
+
 locals {
   lower_name              = length(var.name) > 0 ? replace(lower(var.name), " ", "-") : replace(lower(var.region), " ", "-")
   prefix                  = var.prefix ? "avx-" : ""


### PR DESCRIPTION
Add learned_cidrs_approval_mode
Add logic to disable connected transit when transit firenet egress is enabled (dual transit)